### PR TITLE
feat(dalgo): add public route for city brief dashboard

### DIFF
--- a/src/app/app.route.ts
+++ b/src/app/app.route.ts
@@ -264,10 +264,14 @@ export const appRouter: Routes = [
   {
     path: "dalgo/citybrief-dashboard",
     canActivate: [AuthGuard],
-    loadComponent: () =>
-      import("./pages/dalgo-city-brief/dalgo-city-brief.component").then(
-        (m) => m.DalgoCityBriefComponent
-      ),
+    loadComponent: () => import("./pages/dalgo-city-brief/dalgo-city-brief.component").then((m) => m.DalgoCityBriefComponent),
+    data: { isPublic: false }
+  },
+  {
+    path: "dalgo/publicpage/citybrief-dashboard",
+    // No AuthGuard for the public page
+    loadComponent: () => import("./pages/dalgo-city-brief/dalgo-city-brief.component").then((m) => m.DalgoCityBriefComponent),
+    data: { isPublic: true }
   },
 
   { path: "**", redirectTo: "home" },

--- a/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.html
+++ b/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.html
@@ -1,4 +1,13 @@
 <div id="dalgo-city-brief" class="container mb-5" style="height:100vh;">
     <h5 class="text-center"></h5>
-    <app-dalgo [dashboardType]="'ULB'" [isToShowFilters]="false"></app-dalgo>
+    
+    <!-- Render this tag ONLY for the public route -->
+    <ng-container *ngIf="isPublicRoute">
+        <app-dalgo [dashboardType]="'ULB'"></app-dalgo>
+    </ng-container>
+
+    <!-- Render this tag ONLY for the authenticated/original route -->
+    <ng-container *ngIf="!isPublicRoute">
+        <app-dalgo [dashboardType]="'ULB'" [isToShowFilters]="false"></app-dalgo>
+    </ng-container>
 </div>

--- a/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.ts
+++ b/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.ts
@@ -1,11 +1,24 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { ActivatedRoute } from "@angular/router";
 import { DalgoComponent } from "src/app/shared/components/dalgo/dalgo.component";
 
 @Component({
     standalone: true,
-    imports: [DalgoComponent],
+    imports: [DalgoComponent, CommonModule], // Added CommonModule for *ngIf
     selector: "app-dalgo-city-brief",
     templateUrl: "./dalgo-city-brief.component.html",
     styleUrls: ['./dalgo-city-brief.component.scss']
 })
-export class DalgoCityBriefComponent { }
+export class DalgoCityBriefComponent implements OnInit { 
+    isPublicRoute: boolean = false;
+
+    constructor(private route: ActivatedRoute) {}
+
+    ngOnInit(): void {
+        // Subscribe to route data to check which path loaded the component
+        this.route.data.subscribe(data => {
+            this.isPublicRoute = data['isPublic'] || false;
+        });
+    }
+}

--- a/src/app/shared/components/dalgo/dalgo.component.ts
+++ b/src/app/shared/components/dalgo/dalgo.component.ts
@@ -84,7 +84,7 @@ export class DalgoComponent implements OnInit, AfterViewInit {
     if ((!ulbName || ulbName === 'undefined')) {
       ulbName = sessionStorage.getItem('name') || ulbName;
     }
-    this.filters.push({ id: this.ulbFilterId, column: 'ulb_name', value: ulbName || '' });
+    this.filters.push({ id: this.ulbFilterId, column: 'ulb_name', value: ulbName || 'Bruhat Bengaluru Mahanagara Palike' });
   }
 
   getStateName() {


### PR DESCRIPTION
- Added new route path 'dalgo/publicpage/citybrief-dashboard' reusing DalgoCityBriefComponent.
- Passed 'isPublic' flag via route data to distinguish from the authenticated path.
- Injected ActivatedRoute to read route data in the component.
- Conditionally render app-dalgo component in the template to toggle filters based on the active route.