### PR TITLE
Add XV-FC-REVIEW navigation for ULB users on FC home page

### DIFF
--- a/src/app/pages/fc-grant-home/fc-grant-home-routing.module.ts
+++ b/src/app/pages/fc-grant-home/fc-grant-home-routing.module.ts
@@ -1,16 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { FcHomePageComponent } from './fc-home-page/fc-home-page.component';
+import { AuthGuard } from '../../security/auth-guard.service';
 
 const routes: Routes = [
 
-  { path: "", component:  FcHomePageComponent},
- {
-   path: "**",
-   pathMatch: "full",
-   redirectTo: "",
- }
- ];
+  { path: "", component: FcHomePageComponent, canActivate: [AuthGuard] },
+  {
+    path: "**",
+    pathMatch: "full",
+    redirectTo: "",
+  }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.html
+++ b/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.html
@@ -5,7 +5,8 @@
                 <h3 class="txt-header" style="opacity: 100%; font-size: 35px;">
                     Welcome to 15th Finance Commission Grant Management System </h3>
                 <h3 *ngIf="loggedInUserType == USER_TYPE.ULB" style="opacity: 100%; font-size: 35px;">{{ulbName}}</h3>
-                <h3 *ngIf="loggedInUserType == USER_TYPE.STATE" style="opacity: 100%; font-size: 35px;">{{stateName}}</h3>
+                <h3 *ngIf="loggedInUserType == USER_TYPE.STATE" style="opacity: 100%; font-size: 35px;">{{stateName}}
+                </h3>
                 <h3 *ngIf="loggedInUserType == USER_TYPE.ADMIN
                     || loggedInUserType == USER_TYPE.MoHUA
                     || loggedInUserType == USER_TYPE.PATNER" style="opacity: 100%; font-size: 35px;">{{ulbName}}</h3>
@@ -17,14 +18,16 @@
                     <div class="col-sm-12 text-center">
                         <div *ngFor="let item of yearList" class="" style="display: inline-block;">
                             <!-- <button type="button" class="btn" style="margin-right: 2rem;" routerLink="{{item.url}}" (click)="setId(item?.id)">{{item.year}} </button> -->
-<button
-                type="button"
-                class="btn"
-                style="margin-right: 2rem"
-                (click)="onYearSelect(item)"
-              >
-                {{ item.year }}
-              </button>
+                            <button type="button" class="btn" style="margin-right: 2rem" (click)="onYearSelect(item)">
+                                {{ item.year }}
+                            </button>
+                        </div>
+                        <div class="" style="display: inline-block;" *ngIf="loggedInUserType === USER_TYPE.ULB">
+                            <button type="button" class="btn"
+                                style="margin-right: 2rem; width: auto; min-width: 160px; white-space: nowrap; padding-left: 12px; padding-right: 12px;"
+                                (click)="goToXvFcReview()">
+                                XV-FC-REVIEW
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -33,9 +36,9 @@
             </div>
 
             <div class="text-center mt-4" *ngIf="loggedInUserType === USER_TYPE.ULB">
-              <button type="button" class="btn w-auto" routerLink="/dalgo/citybrief-dashboard">
-                View city brief dashboard
-              </button>
+                <button type="button" class="btn w-auto" routerLink="/dalgo/citybrief-dashboard">
+                    View city brief dashboard
+                </button>
             </div>
         </div>
 

--- a/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.ts
+++ b/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.ts
@@ -13,10 +13,10 @@ import { FcHomePageService } from './fc-home-page.service';
 })
 export class FcHomePageComponent extends BaseComponent implements OnInit {
 
-  constructor(private _router: Router,private _profileService: ProfileService,
-    private location: Location,private fchomepageservice:FcHomePageService ) {
+  constructor(private _router: Router, private _profileService: ProfileService,
+    private location: Location, private fchomepageservice: FcHomePageService) {
     super();
-    if(!this.loggedInUserType){
+    if (!this.loggedInUserType) {
       this._router.navigate(["/fc_grant"]);
     }
     switch (this.loggedInUserType) {
@@ -27,40 +27,40 @@ export class FcHomePageComponent extends BaseComponent implements OnInit {
       case USER_TYPE.ADMIN:
         this._router.navigate(["/fc-home-page"]);
         break;
-        case undefined:
-          case null:
-            return;
-          default:
-            this._router.navigate(["/home"]);
-            break;
+      case undefined:
+      case null:
+        return;
+      default:
+        this._router.navigate(["/home"]);
+        break;
     }
-   // this.fetchProfileData({});
+    // this.fetchProfileData({});
   }
 
- ulbName ='';
- stateName=''
- isULBProfileCompleted: boolean;
- profileData;
- //routerlink2223;
- yearList
- yearList2: any[] = [];
+  ulbName = '';
+  stateName = ''
+  isULBProfileCompleted: boolean;
+  profileData;
+  //routerlink2223;
+  yearList
+  yearList2: any[] = [];
   ngOnInit(): void {
-     let ulbRecord = JSON.parse(localStorage.getItem('userData'));
-     this.ulbName = ulbRecord?.name;
-     this.stateName = ulbRecord?.stateName
-     console.log(ulbRecord)
-     this._profileService.getAccessYears().subscribe((res)=> {
-     this.yearList = res['data'];
-    //  if (this.loggedInUserType === 'STATE') this.yearList = this.yearList.filter((item: any) => item.year != '2025-26');
-    //  console.log('year list data', this.yearList);
-     },
-     (err)=> {
-      console.log(err.message)
-     })
-            const userDataStr = localStorage.getItem('userData');
-            const userData = userDataStr ? JSON.parse(userDataStr) : null;
-             const ulb = userData?.ulb;
-      this.fchomepageservice.getYearsData(ulb).subscribe({
+    let ulbRecord = JSON.parse(localStorage.getItem('userData'));
+    this.ulbName = ulbRecord?.name;
+    this.stateName = ulbRecord?.stateName
+    console.log(ulbRecord)
+    this._profileService.getAccessYears().subscribe((res) => {
+      this.yearList = res['data'];
+      //  if (this.loggedInUserType === 'STATE') this.yearList = this.yearList.filter((item: any) => item.year != '2025-26');
+      //  console.log('year list data', this.yearList);
+    },
+      (err) => {
+        console.log(err.message)
+      })
+    const userDataStr = localStorage.getItem('userData');
+    const userData = userDataStr ? JSON.parse(userDataStr) : null;
+    const ulb = userData?.ulb;
+    this.fchomepageservice.getYearsData(ulb).subscribe({
       next: (res: any) => {
         if (res.status && Array.isArray(res.data)) {
           this.yearList2 = res.data.map((item: any) => ({
@@ -95,17 +95,21 @@ export class FcHomePageComponent extends BaseComponent implements OnInit {
   setId(yearId) {
     sessionStorage.setItem("selectedYearId", yearId);
   }
+
+  goToXvFcReview(): void {
+    window.location.href = window.location.origin + '/fc/xv-fc-review';
+  }
   onYearSelect(item: any): void {
 
     const userDataStr = localStorage.getItem('userData');
-  const userData = userDataStr ? JSON.parse(userDataStr) : null;
-  const role = userData?.role;
+    const userData = userDataStr ? JSON.parse(userDataStr) : null;
+    const role = userData?.role;
     this.setId(item.id);
-if(role==="ULB"){
-const allHaveFiles = this.yearList2.every(
-  (y: any) => !!y.files && Array.isArray(y.files) && y.files.length > 0
-);
-    // if ((item.year === '2024-25' || item.year === '2025-26') && !allHaveFiles) {
+    if (role === "ULB") {
+      const allHaveFiles = this.yearList2.every(
+        (y: any) => !!y.files && Array.isArray(y.files) && y.files.length > 0
+      );
+      // if ((item.year === '2024-25' || item.year === '2025-26') && !allHaveFiles) {
       // const yearId = item.id;
       // Swal.fire({
       //   // title: 'Share your latest budget documents',
@@ -131,16 +135,16 @@ const allHaveFiles = this.yearList2.every(
       //     this._router.navigate([`/ulb-form/${yearId}/budget-documents`]);
       //   }
       // });
-    // } 
-    // else {
+      // } 
+      // else {
       // Regular navigation
       this.setId(item.id);
       this._router.navigate([item.url]);
-    // }
-}
+      // }
+    }
     // Trigger background navigation
     this._router.navigate([item.url]);
-   
+
   }
 
 }


### PR DESCRIPTION
## Summary
- Adds an XV-FC-REVIEW button on the FC home page, visible only to ULB users, that navigates to `/fc/xv-fc-review` via a same-origin full-page redirect (`window.location.origin + '/fc/xv-fc-review'`) — the same pattern already used for `/fc/xvifc-form`, relying on cookies/session rather than passing a token in the URL.
- Adds `canActivate: [AuthGuard]` to the `fc-home-page` route, which previously had no route-level auth check.

## Test plan
- [ ] Repo's CITest suite currently fails to compile for unrelated pre-existing reasons (broken specs in `mform_webform` directives and `file-upload.component.spec.ts`) — not exercised for this change.
- [ ] Manually verify: logged in as ULB, "XV-FC-REVIEW" button is visible and navigates to `/fc/xv-fc-review`.
- [ ] Manually verify: logged in as STATE/ADMIN/MoHUA/PMU, button is not shown.
- [ ] Manually verify: unauthenticated access to `/fc-home-page` redirects via AuthGuard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)