### PR TITLE
Move XV-FC-REVIEW button from FC home page to app-dalgo component

### DIFF
--- a/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.html
+++ b/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.html
@@ -1,4 +1,4 @@
-<div id="dalgo-city-brief" class="container mb-5" style="height:100vh;">
+<div id="dalgo-city-brief" class="container mb-5" style="min-height:100vh;">
     <h5 class="text-center"></h5>
     
     <!-- Render this tag ONLY for the public route -->

--- a/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.scss
+++ b/src/app/pages/dalgo-city-brief/dalgo-city-brief.component.scss
@@ -1,25 +1,15 @@
 #dalgo-city-brief {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   padding: 0 !important;
   margin: 0 auto !important;
   max-width: 96% !important;
   display: block;
 }
 
-#dalgo-city-brief app-dalgo,
-#dalgo-city-brief app-dalgo > * {
+#dalgo-city-brief app-dalgo {
   display: block;
   width: 100%;
-  height: 100%;
-}
-
-#dalgo-city-brief #mohua-superset-container {
-  width: 100% !important;
-  height: 100% !important;
-  padding: 0 !important;
-  margin: 0 auto !important;
-  max-width: 96% !important;
 }
 
 #dalgo-city-brief #mohua-superset-container iframe {

--- a/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.html
+++ b/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.html
@@ -22,13 +22,6 @@
                                 {{ item.year }}
                             </button>
                         </div>
-                        <div class="" style="display: inline-block;" *ngIf="loggedInUserType === USER_TYPE.ULB">
-                            <button type="button" class="btn"
-                                style="margin-right: 2rem; width: auto; min-width: 160px; white-space: nowrap; padding-left: 12px; padding-right: 12px;"
-                                (click)="goToXvFcReview()">
-                                XV-FC-REVIEW
-                            </button>
-                        </div>
                     </div>
                 </div>
 

--- a/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.ts
+++ b/src/app/pages/fc-grant-home/fc-home-page/fc-home-page.component.ts
@@ -96,9 +96,6 @@ export class FcHomePageComponent extends BaseComponent implements OnInit {
     sessionStorage.setItem("selectedYearId", yearId);
   }
 
-  goToXvFcReview(): void {
-    window.location.href = window.location.origin + '/fc/xv-fc-review';
-  }
   onYearSelect(item: any): void {
 
     const userDataStr = localStorage.getItem('userData');

--- a/src/app/shared/components/dalgo/dalgo.component.html
+++ b/src/app/shared/components/dalgo/dalgo.component.html
@@ -1,1 +1,6 @@
 <div id="mohua-superset-container" class="container" style="height: 100vh;"></div>
+<div class="text-start xv-fc-review-container" *ngIf="dashboardType === USER_TYPE.ULB">
+    <button type="button" class="btn xv-fc-review-btn" (click)="goToXvFcReview()">
+        XV-FC-REVIEW
+    </button>
+</div>

--- a/src/app/shared/components/dalgo/dalgo.component.scss
+++ b/src/app/shared/components/dalgo/dalgo.component.scss
@@ -5,3 +5,30 @@ padding: 0 !important;
 margin: 0 auto !important;
 max-width: 96% !important;
 }
+
+.xv-fc-review-container {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+}
+
+.xv-fc-review-btn {
+    background-color: rgb(252, 195, 8);
+    padding: 5px 5px;
+    color: #FFFFFF;
+    height: 36px;
+    width: auto;
+    min-width: 160px;
+    white-space: nowrap;
+    padding-left: 12px;
+    padding-right: 12px;
+    font-weight: 700;
+    font-size: 1rem;
+    border: none;
+}
+
+.xv-fc-review-btn:hover {
+    background-color: #f1ba02;
+    color: #FFFFFF;
+    font-weight: 600;
+}

--- a/src/app/shared/components/dalgo/dalgo.component.ts
+++ b/src/app/shared/components/dalgo/dalgo.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { embedDashboard } from '@superset-ui/embedded-sdk';
 import { CommonServicesService } from 'src/app/fc-grant-2324-onwards/fc-shared/service/common-services.service';
 import { USER_TYPE } from 'src/app/models/user/userType';
@@ -11,10 +12,13 @@ import { IUserLoggedInDetails } from 'src/app/models/login/userLoggedInDetails';
   selector: 'app-dalgo',
   templateUrl: './dalgo.component.html',
   styleUrls: ['./dalgo.component.scss'],
-  standalone: true
+  standalone: true,
+  imports: [CommonModule]
 })
 
 export class DalgoComponent implements OnInit, AfterViewInit {
+
+  readonly USER_TYPE = USER_TYPE;
 
   private readonly htmlElementId = 'mohua-superset-container';  // Element ID as a constant
   private readonly supersetDomainUrl = 'https://janaagraha.dalgo.org/';
@@ -85,6 +89,10 @@ export class DalgoComponent implements OnInit, AfterViewInit {
       ulbName = sessionStorage.getItem('name') || ulbName;
     }
     this.filters.push({ id: this.ulbFilterId, column: 'ulb_name', value: ulbName || 'Bruhat Bengaluru Mahanagara Palike' });
+  }
+
+  goToXvFcReview(): void {
+    window.location.href = window.location.origin + '/fc/xv-fc-review';
   }
 
   getStateName() {


### PR DESCRIPTION
## Summary
- Moves the XV-FC-REVIEW button for ULB users out of the FC home page and into the shared `app-dalgo` component, shown at the bottom of the embedded Superset dashboard (left-aligned), with the same navigation behavior (`/fc/xv-fc-review`).
- Fixes a pre-existing layout bug in `dalgo-city-brief` where a fixed `height: 100vh` on the wrapper caused the site footer to visually overlap/cover content below the dashboard (changed to `min-height: 100vh` and removed redundant cross-component height rules).

## Test plan
- [x] Verified via headless-browser check that the button renders correctly below the dashboard on `/dalgo/publicpage/citybrief-dashboard` with no overlap from the footer.
- [ ] Manually verify on `/dalgo/citybrief-dashboard` (authenticated route) and other ULB pages embedding `app-dalgo` (e.g. `ulb-form/overview`, `xvfc2223-ulb/overview`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)