### PR TITLE
Add footnote with link for XV-FC-REVIEW on FC home page

### DIFF
--- a/src/app/shared/components/dalgo/dalgo.component.html
+++ b/src/app/shared/components/dalgo/dalgo.component.html
@@ -1,6 +1,10 @@
 <div id="mohua-superset-container" class="container" style="height: 100vh;"></div>
 <div class="text-start xv-fc-review-container" *ngIf="dashboardType === USER_TYPE.ULB">
-    <button type="button" class="btn xv-fc-review-btn" (click)="goToXvFcReview()">
-        XV-FC-REVIEW
-    </button>
+    <p class="xv-fc-review-footnote">
+        <span class="material-icons xv-fc-review-footnote-icon">info</span>
+        <span>
+            <a href="javascript:void(0)" class="xv-fc-review-link" (click)="goToXvFcReview()">Click here</a>
+            to review your digitized data. You can edit it if any discrepancies are found. Once reviewed, you must accept the reported data, even if no changes are required.
+        </span>
+    </p>
 </div>

--- a/src/app/shared/components/dalgo/dalgo.component.scss
+++ b/src/app/shared/components/dalgo/dalgo.component.scss
@@ -12,23 +12,33 @@ max-width: 96% !important;
     padding-left: 1.5rem;
 }
 
-.xv-fc-review-btn {
-    background-color: rgb(252, 195, 8);
-    padding: 5px 5px;
-    color: #FFFFFF;
-    height: 36px;
-    width: auto;
-    min-width: 160px;
-    white-space: nowrap;
-    padding-left: 12px;
-    padding-right: 12px;
-    font-weight: 700;
-    font-size: 1rem;
-    border: none;
+.xv-fc-review-footnote {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    width: 100%;
+    margin: 0;
+    color: #343a40;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    line-height: 20px;
 }
 
-.xv-fc-review-btn:hover {
-    background-color: #f1ba02;
-    color: #FFFFFF;
-    font-weight: 600;
+.xv-fc-review-footnote-icon {
+    font-size: 18px;
+    line-height: 20px;
+    color: #193369;
+    flex-shrink: 0;
+}
+
+.xv-fc-review-link {
+    color: #193369;
+    font-weight: 700;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.xv-fc-review-link:hover {
+    color: #12244d;
+    text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- Replaced the standalone XV-FC-REVIEW button on the FC home page (dalgo component) with an inline footnote explaining the review flow.
- "Click here" is now the actionable link (styled in `#193369`) that triggers navigation to the XV FC review page, matching the requested feedback copy:
  > "Click here to review your digitized data. You can edit it if any discrepancies are found. Once reviewed, you must accept the reported data, even if no changes are required."
- Fixed icon/text baseline alignment and improved text visibility/contrast.

## Test plan
- Verified locally that the footnote renders for ULB users on the FC home page and the "Click here" link navigates via `goToXvFcReview()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)